### PR TITLE
Fix a return statement.

### DIFF
--- a/pd2-lua/lib/managers/menu/stageendscreengui.lua
+++ b/pd2-lua/lib/managers/menu/stageendscreengui.lua
@@ -263,7 +263,7 @@ function StatsTabItem:set_stats(stats_data)
 			prev_stat_panel = new_stat_panel
 		end
 
-		break
+		return
 	end
 
 	for i, stat in ipairs(self._stats) do


### PR DESCRIPTION
The decompiler had a small issue where in some situations breaks were used when they shouldn't have. This fixes the only case where that bug was a problem.